### PR TITLE
Implicit AND everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,9 @@ SearchQL can generate a data representation of the query:
 ```elixir
 [or: {
   [or: {
-    [and: {[data: "foo"], [data: "bar"]}],
+    [data: "foo", data: "bar"],
     [quote: "qux AND quux"]}],
-  [and: {
-    [and: {[data: "corge"], [not: {[data: "grault"]}]}],
-    [data: "garply"]}]}]
+  [data: "corge", not: {[data: "grault"]}, data: "garply"]}]
 ```
 
 Notice that in the query parsing, `AND` binds tighter than `OR`, and both

--- a/lib/searchql.ex
+++ b/lib/searchql.ex
@@ -29,8 +29,6 @@ defmodule SearchQL do
   @spec token_matches?(token, any, atom) :: boolean
   defp token_matches?(tokens, data, mod) when is_list(tokens),
     do: do_matches?(tokens, data, mod)
-  defp token_matches?({:and, {tok_a, tok_b}}, data, mod),
-    do: token_matches?(tok_a, data, mod) and token_matches?(tok_b, data, mod)
   defp token_matches?({:or, {tok_a, tok_b}}, data, mod),
     do: token_matches?(tok_a, data, mod) or token_matches?(tok_b, data, mod)
   defp token_matches?({:not, {tokens}}, data, mod),

--- a/lib/searchql/logical_parser.ex
+++ b/lib/searchql/logical_parser.ex
@@ -10,7 +10,7 @@ defmodule SearchQL.LogicalParser do
   replaced by logical tokens. Note that logical parsing is case-**in**sensitive.
 
       iex> SearchQL.LogicalParser.parse([data: "foo and bar"])
-      [and: {[data: "foo"], [data: "bar"]}]
+      [data: "foo", data: "bar"]
 
   This function parses tokens in reverse order, "OR"s before "AND"s. This
   results in a parsing where "AND" has the higher precedence, and where operator
@@ -19,11 +19,7 @@ defmodule SearchQL.LogicalParser do
       iex> SearchQL.LogicalParser.parse([data: "foo or bar and baz and qux"])
       [or: {
         [data: "foo"],
-        [and: {
-          [and: {
-            [data: "bar"],
-            [data: "baz"]}],
-          [data: "qux"]}]}]
+        [data: "bar", data: "baz", data: "qux"]}]
   """
   @spec parse([SearchQL.token]) :: [SearchQL.token]
   def parse(tokens), do: tokens |> Enum.reduce([], &make_words/2) |> parse_or
@@ -40,7 +36,7 @@ defmodule SearchQL.LogicalParser do
   defp parse_and(tokens, result \\ [])
   defp parse_and([], result), do: result |> Enum.reverse |> parse_not
   defp parse_and([{:word, word} | tokens], result) when word in ~w(and AND),
-    do: [{:and, {parse_and(tokens), parse_and([], result)}}]
+    do: parse_and(tokens) ++ parse_and([], result)
   defp parse_and([token | tokens], result),
     do: parse_and(tokens, [token | result])
 

--- a/test/lib/searchql/logical_parser_test.exs
+++ b/test/lib/searchql/logical_parser_test.exs
@@ -24,25 +24,19 @@ defmodule SearchQL.LogicalParserTest do
 
   test "parses AND expressions" do
     assert LogicalParser.parse([{:data, "foo AND bar"}]) ==
-      [and: {[data: "foo"], [data: "bar"]}]
+      [data: "foo", data: "bar"]
   end
 
   test "parses AND as left-associative" do
     assert LogicalParser.parse([{:data, "foo AND bar AND baz"}]) ==
-      [and: {
-        [and: {
-          [data: "foo"],
-          [data: "bar"]}],
-        [data: "baz"]}]
+      [data: "foo", data: "bar", data: "baz"]
   end
 
   test "parses AND with higher precedence than OR" do
     assert LogicalParser.parse([{:data, "foo OR bar AND baz qux"}]) ==
       [or: {
         [data: "foo"],
-        [and: {
-          [data: "bar"],
-          [data: "baz qux"]}]}]
+        [data: "bar", data: "baz qux"]}]
   end
 
   test "parses already-parsed expressions" do
@@ -58,17 +52,13 @@ defmodule SearchQL.LogicalParserTest do
 
   test "parses NOT" do
     assert LogicalParser.parse([data: "foo AND NOT bar"]) ==
-      [and: {
-        [data: "foo"],
-        [not: {[data: "bar"]}]}]
+      [data: "foo", not: {[data: "bar"]}]
   end
 
   test "parses NOT with higher binding than OR" do
     assert LogicalParser.parse([data: "foo AND NOT bar OR baz"]) ==
       [or: {
-        [and: {
-          [data: "foo"],
-          [not: {[data: "bar"]}]}],
+        [data: "foo", not: {[data: "bar"]}],
         [data: "baz"]}]
   end
 end

--- a/test/searchql_test.exs
+++ b/test/searchql_test.exs
@@ -68,7 +68,7 @@ defmodule SearchQLTest do
   describe ".parse/1" do
     test "parses combined logical and quotes" do
       assert SearchQL.parse(~s("foo bar" AND baz)) ==
-        [and: {[quote: "foo bar"], [data: "baz"]}]
+        [quote: "foo bar", data: "baz"]
     end
   end
 end


### PR DESCRIPTION
The combination of lists (which are an implicit AND) with the `{:and, _}` tagged tuple is a little confusing. I'm wondering if it's better to eliminate that tuple altogether:

Given the query: `foo AND "bar AND baz" OR qux`, generate this:

```elixir
[or: {
  [data: "foo", quote: "bar AND baz"],
  [data: "qux"]}]
```